### PR TITLE
Have the dependency between decorator and index be more explicit

### DIFF
--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -10,9 +10,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var _ = require('./');
+var _index = require('./index');
 
-var _2 = _interopRequireDefault(_);
+var _index2 = _interopRequireDefault(_index);
 
 var _react = require('react');
 
@@ -37,7 +37,7 @@ exports['default'] = function () {
 
       LazyLoadDecorated.prototype.render = function render() {
         return _react2['default'].createElement(
-          _2['default'],
+          _index2['default'],
           options,
           _react2['default'].createElement(WrappedComponent, this.props)
         );

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,4 +1,4 @@
-import LazyLoad from './';
+import LazyLoad from './index';
 import React, { Component } from 'react';
 
 const getDisplayName = (WrappedComponent) => {


### PR DESCRIPTION
I have a particular use case of this module where I need to support running AMD-ification via babel on this module in order to have the code work in my environment. That process (using the babel plugin `transform-es2015-modules-amd`) works, but then the AMD-ified `decorator.js` tries to require the file "./" which blows up. The fix is quite simple - to specify that "./" is actually referring to "./index".