### PR TITLE
Support non-nodejs environments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ class LazyLoad extends Component {
   }
 
   componentDidMount() {
-    if (process.env.NODE_ENV !== 'production') {
+    if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
       if (React.Children.count(this.props.children) > 1) {
         console.warn('[react-lazyload] Only one child is allowed to be passed to `LazyLoad`.');
       }


### PR DESCRIPTION
Hello! We've been using react-lazyload at our company for making React components lazyload both in a nodeJS and not in a nodeJS environment, and the latter one doesn't work because of the assumption that `process` is a defined variable. This PR just puts in a check to make sure the variable exists before accessing it and is pretty harmless.