### PR TITLE
fix: use same remove-listener logic for `overflow:true`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ class LazyLoad extends Component {
       if (React.Children.count(this.props.children) > 1) {
         console.warn('[react-lazyload] Only one child is allowed to be passed to `LazyLoad`.');
       }
-  
+
       if (this.props.wheel) { // eslint-disable-line
         console.warn('[react-lazyload] Props `wheel` is not supported anymore, try set `overflow` for lazy loading in overflow containers.');
       }
@@ -209,22 +209,22 @@ class LazyLoad extends Component {
   }
 
   componentWillUnmount() {
-    if (this.props.overflow) {
-      const parent = scrollParent(ReactDom.findDOMNode(this));
-      if (parent) {
-        parent.removeEventListener('scroll', finalLazyLoadHandler);
-        parent.removeAttribute(LISTEN_FLAG);
-      }
-    }
-
     const index = listeners.indexOf(this);
     if (index !== -1) {
       listeners.splice(index, 1);
     }
 
     if (listeners.length === 0) {
-      off(window, 'resize', finalLazyLoadHandler);
-      off(window, 'scroll', finalLazyLoadHandler);
+      if (this.props.overflow) {
+        const parent = scrollParent(ReactDom.findDOMNode(this));
+        if (parent) {
+          parent.removeEventListener('scroll', finalLazyLoadHandler);
+          parent.removeAttribute(LISTEN_FLAG);
+        }
+      } else {
+        off(window, 'resize', finalLazyLoadHandler);
+        off(window, 'scroll', finalLazyLoadHandler);
+      }
     }
   }
 


### PR DESCRIPTION
Not sure how this normally works, but I was unable to use `overflow` without this update, because if _any_ LazyLoad unmounted, it would remove the parent's scroll listener.

This PR updates the unmount handler to use the same `if (listeners.length === 0)` logic to remove the parent's listener only once there are no listeners remaining.

Though upon reflection, I think `overflow` mode actually ought to maintain a `listeners` list per parent, for completely correct behavior...