### PR TITLE
Provide option to unmount lazy loaded components when they are no longer visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ class MyComponent extends React.Component {
 }
 ```
 
-You should aware that your component will only be mounted when it's visible in viewport, before that a placeholder will be rendered. 
+You should aware that your component will only be mounted when it's visible in viewport, before that a placeholder will be rendered.
 
 So you can safely send request in your component's `componentDidMount` without worring about performance loss or add some pretty entering effect, see this [demo](https://jasonslyvia.github.io/react-lazyload/examples/#/fadein) for more detail.
 
@@ -150,6 +150,12 @@ Specify a placeholder for your lazy loaded component.
 [demo](https://jasonslyvia.github.io/react-lazyload/examples/#/placeholder)
 
 **If you provide your own placeholder, do remember add appropriate `height` or `minHeight` to your placeholder element for better lazyload performance.**
+
+### unmountIfInvisible
+
+Type: Bool Default: false
+
+The lazy loaded component is unmounted and replaced by the placeholder when it is no longer visible in the viewport.
 
 ## Utility
 

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,9 @@ const checkVisible = function checkVisible(component) {
     }
   } else if (!(component.props.once && component.visible)) {
     component.visible = false;
+    if (component.props.unmountIfInvisible) {
+      component.forceUpdate();
+    }
   }
 };
 
@@ -255,7 +258,8 @@ LazyLoad.propTypes = {
   children: PropTypes.node,
   throttle: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   debounce: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
-  placeholder: PropTypes.node
+  placeholder: PropTypes.node,
+  unmountIfInvisible: PropTypes.bool
 };
 
 LazyLoad.defaultProps = {
@@ -263,7 +267,8 @@ LazyLoad.defaultProps = {
   offset: 0,
   overflow: false,
   resize: false,
-  scroll: true
+  scroll: true,
+  unmountIfInvisible: false
 };
 
 import decorator from './decorator';


### PR DESCRIPTION
I've got a project where I'd like to lazy load some iframes but also unload them when they aren't visible, to save resources. Here's my attempt at implementing that.