### PR TITLE
Check for css visibility before doing normal on scroll visibility checks

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -65,6 +65,9 @@ const checkOverflowVisible = function checkOverflowVisible(component, parent) {
 const checkNormalVisible = function checkNormalVisible(component) {
   const node = ReactDom.findDOMNode(component);
 
+  // If this element is hidden by css rules somehow, it's definitely invisible
+  if (!(node.offsetWidth || node.offsetHeight || node.getClientRects().length)) return false;
+
   let top;
   let elementHeight;
 


### PR DESCRIPTION
We had a case where a LazyLoad-wrapped image was still being downloaded on page load despite never being displayed on the page due to its parent component having the css rule `display: none` applied to it. This meant that its client bounding rect was width/height 0, and top/right/bottom/left 0, and thus was "visible" on page load according to the previous calculations.

I got the fix from http://stackoverflow.com/a/33456469