### PR TITLE
move prop-types to be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/jasonslyvia/react-lazyload/issues"
   },
   "homepage": "https://github.com/jasonslyvia/react-lazyload",
+  "dependencies": {
+    "prop-types": "^15.5.6"
+  },
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
@@ -58,8 +61,7 @@
     "react-hot-loader": "~1.3.1",
     "react-router": "^2.0.1",
     "webpack": "~1.11.0",
-    "webpack-dev-server": "~1.10.1",
-    "prop-types": "^15.5.6"
+    "webpack-dev-server": "~1.10.1"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
since we import proptypes in src/index.jsx but only require it as a
devdependency, when this package is used it throws an error
`unable to find package prop-types`

https://github.com/reactjs/prop-types#how-to-depend-on-this-package
reccomends depending on prop-types as a dependency, not a dev dependency
for this reason.