### PR TITLE
Check for any overflow scroll style on parent node.

### DIFF
--- a/lib/utils/scrollParent.js
+++ b/lib/utils/scrollParent.js
@@ -33,7 +33,7 @@ exports.default = function (node) {
       continue;
     }
 
-    if (overflowRegex.test(overflow) && overflowRegex.test(overflowX) && overflowRegex.test(overflowY)) {
+    if (overflowRegex.test(overflow) || overflowRegex.test(overflowX) || overflowRegex.test(overflowY)) {
       return parent;
     }
 


### PR DESCRIPTION
I believe that the current check for overflow styles is incorrect and that the following patch fixes it (assuming that I'm not misunderstanding how this is meant to be working).

This may (in part at least) fix https://github.com/jasonslyvia/react-lazyload/issues/96.