### PR TITLE
fixes #168 allow for custom scroll container

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,6 +204,10 @@ var lazyLoadHandler = function lazyLoadHandler() {
 var delayType = void 0;
 var finalLazyLoadHandler = null;
 
+var isString = function isString(string) {
+  return typeof string === 'string';
+};
+
 var LazyLoad = function (_Component) {
   _inherits(LazyLoad, _Component);
 
@@ -219,35 +223,20 @@ var LazyLoad = function (_Component) {
   _createClass(LazyLoad, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
-        if (_react2.default.Children.count(this.props.children) > 1) {
-          console.warn('[react-lazyload] Only one child is allowed to be passed to `LazyLoad`.');
-        }
-
-        if (this.props.wheel) {
-          // eslint-disable-line
-          console.warn('[react-lazyload] Props `wheel` is not supported anymore, try set `overflow` for lazy loading in overflow containers.');
-        }
-
-        // Warn the user if placeholder and height is not specified and the rendered height is 0
-        if (!this.props.placeholder && this.props.height === undefined && _reactDom2.default.findDOMNode(this).offsetHeight === 0) {
-          console.warn('[react-lazyload] Please add `height` props to <LazyLoad> for better performance.');
-        }
-      }
-
       // It's unlikely to change delay type on the fly, this is mainly
       // designed for tests
-      var needResetFinalLazyLoadHandler = false;
-      if (this.props.debounce !== undefined && delayType === 'throttle') {
-        console.warn('[react-lazyload] Previous delay function is `throttle`, now switching to `debounce`, try setting them unanimously');
-        needResetFinalLazyLoadHandler = true;
-      } else if (delayType === 'debounce' && this.props.debounce === undefined) {
-        console.warn('[react-lazyload] Previous delay function is `debounce`, now switching to `throttle`, try setting them unanimously');
-        needResetFinalLazyLoadHandler = true;
+      var scrollport = window;
+      var scrollContainer = this.props.scrollContainer;
+
+      if (scrollContainer) {
+        if (isString(scrollContainer)) {
+          scrollport = scrollport.document.querySelector(scrollContainer);
+        }
       }
+      var needResetFinalLazyLoadHandler = this.props.debounce !== undefined && delayType === 'throttle' || delayType === 'debounce' && this.props.debounce === undefined;
 
       if (needResetFinalLazyLoadHandler) {
-        (0, _event.off)(window, 'scroll', finalLazyLoadHandler, passiveEvent);
+        (0, _event.off)(scrollport, 'scroll', finalLazyLoadHandler, passiveEvent);
         (0, _event.off)(window, 'resize', finalLazyLoadHandler, passiveEvent);
         finalLazyLoadHandler = null;
       }
@@ -280,7 +269,7 @@ var LazyLoad = function (_Component) {
 
 
         if (scroll) {
-          (0, _event.on)(window, 'scroll', finalLazyLoadHandler, passiveEvent);
+          (0, _event.on)(scrollport, 'scroll', finalLazyLoadHandler, passiveEvent);
         }
 
         if (resize) {
@@ -343,6 +332,7 @@ LazyLoad.propTypes = {
   throttle: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.bool]),
   debounce: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.bool]),
   placeholder: _propTypes2.default.node,
+  scrollContainer: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
   unmountIfInvisible: _propTypes2.default.bool
 };
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -169,7 +169,6 @@ let delayType;
 let finalLazyLoadHandler = null;
 
 const isString = string => typeof string === 'string';
-// const isDomNode = domNode => domNode instanceof HTMLElement;
 
 class LazyLoad extends Component {
   constructor(props) {
@@ -187,13 +186,8 @@ class LazyLoad extends Component {
     } = this.props;
     if (scrollContainer) {
       if (isString(scrollContainer)) {
-        // selector
         scrollport = scrollport.document.querySelector(scrollContainer);
       }
-      //  else if (isDomNode(scrollContainer)) {
-      //   // is dom node
-      //   scrollport = scrollContainer;
-      // }
     }
     const needResetFinalLazyLoadHandler = (this.props.debounce !== undefined && delayType === 'throttle')
       || (delayType === 'debounce' && this.props.debounce === undefined);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -169,7 +169,7 @@ let delayType;
 let finalLazyLoadHandler = null;
 
 const isString = string => typeof string === 'string';
-const isDomNode = domNode => domNode instanceof HTMLElement;
+// const isDomNode = domNode => domNode instanceof HTMLElement;
 
 class LazyLoad extends Component {
   constructor(props) {
@@ -181,24 +181,25 @@ class LazyLoad extends Component {
   componentDidMount() {
     // It's unlikely to change delay type on the fly, this is mainly
     // designed for tests
-    let viewport = window;
+    let scrollport = window;
     const {
       scrollContainer,
     } = this.props;
     if (scrollContainer) {
       if (isString(scrollContainer)) {
         // selector
-        viewport = viewport.document.querySelector(scrollContainer);
-      } else if (isDomNode(scrollContainer)) {
-        // is dom node
-        viewport = scrollContainer;
+        scrollport = scrollport.document.querySelector(scrollContainer);
       }
+      //  else if (isDomNode(scrollContainer)) {
+      //   // is dom node
+      //   scrollport = scrollContainer;
+      // }
     }
     const needResetFinalLazyLoadHandler = (this.props.debounce !== undefined && delayType === 'throttle')
       || (delayType === 'debounce' && this.props.debounce === undefined);
 
     if (needResetFinalLazyLoadHandler) {
-      off(viewport, 'scroll', finalLazyLoadHandler, passiveEvent);
+      off(scrollport, 'scroll', finalLazyLoadHandler, passiveEvent);
       off(window, 'resize', finalLazyLoadHandler, passiveEvent);
       finalLazyLoadHandler = null;
     }
@@ -232,7 +233,7 @@ class LazyLoad extends Component {
       const { scroll, resize } = this.props;
 
       if (scroll) {
-        on(viewport, 'scroll', finalLazyLoadHandler, passiveEvent);
+        on(scrollport, 'scroll', finalLazyLoadHandler, passiveEvent);
       }
 
       if (resize) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -168,6 +168,8 @@ const lazyLoadHandler = () => {
 let delayType;
 let finalLazyLoadHandler = null;
 
+const isString = string => typeof string === 'string';
+const isDomNode = domNode => domNode instanceof HTMLElement;
 
 class LazyLoad extends Component {
   constructor(props) {
@@ -179,11 +181,24 @@ class LazyLoad extends Component {
   componentDidMount() {
     // It's unlikely to change delay type on the fly, this is mainly
     // designed for tests
+    let viewport = window;
+    const {
+      scrollContainer,
+    } = this.props;
+    if (scrollContainer) {
+      if (isString(scrollContainer)) {
+        // selector
+        viewport = viewport.document.querySelector(scrollContainer);
+      } else if (isDomNode(scrollContainer)) {
+        // is dom node
+        viewport = scrollContainer;
+      }
+    }
     const needResetFinalLazyLoadHandler = (this.props.debounce !== undefined && delayType === 'throttle')
       || (delayType === 'debounce' && this.props.debounce === undefined);
 
     if (needResetFinalLazyLoadHandler) {
-      off(window, 'scroll', finalLazyLoadHandler, passiveEvent);
+      off(viewport, 'scroll', finalLazyLoadHandler, passiveEvent);
       off(window, 'resize', finalLazyLoadHandler, passiveEvent);
       finalLazyLoadHandler = null;
     }
@@ -217,7 +232,7 @@ class LazyLoad extends Component {
       const { scroll, resize } = this.props;
 
       if (scroll) {
-        on(window, 'scroll', finalLazyLoadHandler, passiveEvent);
+        on(viewport, 'scroll', finalLazyLoadHandler, passiveEvent);
       }
 
       if (resize) {
@@ -278,6 +293,7 @@ LazyLoad.propTypes = {
   throttle: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   debounce: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   placeholder: PropTypes.node,
+  scrollContainer: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   unmountIfInvisible: PropTypes.bool
 };
 

--- a/test/specs/lazyload.spec.js
+++ b/test/specs/lazyload.spec.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import LazyLoad, { lazyload } from '../../src/index';
 import spies from 'chai-spies';
 import Test from '../Test.component';
+import * as event from '../../src/utils/event';
 
 chai.use(spies);
 const expect = chai.expect;
@@ -243,6 +244,53 @@ describe('LazyLoad', () => {
       expect(container.querySelector('.something')).to.exist;
       expect(container.querySelector('.lazyload-placeholder')).not.to.exist;
       expect(container.querySelector('.treasure')).to.exist;
+    });
+  });
+
+  describe('scrollContainer', () => {
+    it('should focus on a different scroll container', (done) => {
+      const $body = document.body;
+      const $html = $body.parentNode;
+      const $els = [$body, $html, div];
+      setStyle('100%');
+      ReactDOM.render(
+        <div
+          id="scroll-container"
+          style={{ height: '100%', width: '100%', overflow: 'auto' }}>
+          <div
+            id="scroller"
+            style={{ height: 10000 }}>
+            <div
+              id="spacer"
+              style={{ height: 10000 - 200 }}></div>
+            <LazyLoad
+              height={200}
+              scrollContainer="#scroll-container">
+              <div id="content" style={{ height: 200, width: '100%' }}></div>
+            </LazyLoad>
+          </div>
+        </div>
+      , div);
+      const $container = document.querySelector('#scroll-container');
+      event.on($container, 'scroll', scroller);
+      expect($container.querySelector('.lazyload-placeholder')).to.exist;
+      expect($container.querySelector('#content')).not.to.exist;
+      $container.scrollTop = $container.scrollHeight - window.innerHeight;
+
+      function setStyle(value) {
+        $els.forEach($el => {
+          $el.style.height = value;
+          $el.style.width = value;
+        });
+      }
+
+      function scroller() {
+        expect($container.querySelector('.lazyload-placeholder')).not.to.exist;
+        expect($container.querySelector('#content')).to.exist;
+        setStyle('');
+        event.off($container, 'scroll', scroller);
+        done();
+      }
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,6 +2075,12 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "http://registry.npm.taobao.org/fresh/download/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+fs-access@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
+  dependencies:
+    null-check "^1.0.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "http://registry.npm.taobao.org/fs-readdir-recursive/download/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -2714,6 +2720,13 @@ karma-chai@^0.1.0:
   version "0.1.0"
   resolved "http://registry.npm.taobao.org/karma-chai/download/karma-chai-0.1.0.tgz#bee5ad40400517811ae34bb945f762909108b79a"
 
+karma-chrome-launcher@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
+  dependencies:
+    fs-access "^1.0.0"
+    which "^1.2.1"
+
 karma-coverage@^0.5.5:
   version "0.5.5"
   resolved "http://registry.npm.taobao.org/karma-coverage/download/karma-coverage-0.5.5.tgz#b0d58b1025d59d5c6620263186f1d58f5d5348c5"
@@ -3130,6 +3143,10 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+null-check@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/null-check/-/null-check-1.0.0.tgz#977dffd7176012b9ec30d2a39db5cf72a0439edd"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -4433,7 +4450,7 @@ whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "http://registry.npm.taobao.org/whatwg-fetch/download/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
-which@^1.1.1:
+which@^1.1.1, which@^1.2.1:
   version "1.3.0"
   resolved "http://registry.npm.taobao.org/which/download/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
basic premise is to pass an id which can be queried for when the element mounts