### PR TITLE
Attach to both the window and the parent if overvlow parent is present

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,6 +12,7 @@ import throttle from './utils/throttle';
 const defaultBoundingClientRect = { top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0 };
 const LISTEN_FLAG = 'data-lazyload-listened';
 const listeners = [];
+let isWindowListenerAttached = false;
 let pending = [];
 
 // try to handle passive events
@@ -213,7 +214,8 @@ class LazyLoad extends Component {
         }
         parent.setAttribute(LISTEN_FLAG, listenerCount);
       }
-    } else if (listeners.length === 0 || needResetFinalLazyLoadHandler) {
+    }
+    if (!isWindowListenerAttached || needResetFinalLazyLoadHandler) {
       const { scroll, resize } = this.props;
 
       if (scroll) {
@@ -223,6 +225,8 @@ class LazyLoad extends Component {
       if (resize) {
         on(window, 'resize', finalLazyLoadHandler, passiveEvent);
       }
+
+      isWindowListenerAttached = true;
     }
 
     listeners.push(this);


### PR DESCRIPTION
Proposal to fix #172 

**NB:** Breaks the test checking for rendering only once since it attaches to both parent and window:
https://github.com/jasonslyvia/react-lazyload/blob/552315242635d0bf36c5387d644e6eded6641ce6/test/specs/lazyload.spec.js#L74