### PR TITLE
Determine if the node  is a dom object

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -113,7 +113,7 @@ const checkNormalVisible = function checkNormalVisible(component) {
  */
 const checkVisible = function checkVisible(component) {
   const node = ReactDom.findDOMNode(component);
-  if (!node) {
+  if (!(node instanceof HTMLElement)) {
     return;
   }
 

--- a/src/utils/scrollParent.js
+++ b/src/utils/scrollParent.js
@@ -3,7 +3,7 @@
  */
 
 export default (node) => {
-  if (!node) {
+  if (!(node instanceof HTMLElement)) {
     return document.documentElement;
   }
 


### PR DESCRIPTION
If the child node is not a dom object, the subsequent operation reports an error (because this is the action that presupposes the creation of the dom object)